### PR TITLE
Add option to define how current version is stored.

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -15,9 +15,9 @@ module.exports = CoreObject.extend({
   init: function() {
     this.manifestSize = this.manifestSize || DEFAULT_MANIFEST_SIZE;
     
-    if (this.config.copyOnActivate) {
-      this.copyOnActivate = true;
-      delete this.config.copyOnActivate;
+    if (this.config.copyToKey) {
+      this.copyToKey = this.config.copyToKey;
+      delete this.config.copyToKey;
     }
 
     this.client = redis.createClient(this.config);
@@ -50,17 +50,15 @@ module.exports = CoreObject.extend({
       return this._printErrorMessage(this._noRevisionPassedMessage());
     };
 
-    var currentKey = this._currentKey();
-    var that      = this;
+    var that = this;
 
     return new RSVP.Promise(function(resolve, reject) {
       that._checkVersion(revisionKey).then(
         function() {
-          that._activateVersion(currentKey, revisionKey).then(resolve, reject);
+          that._activateVersion(revisionKey).then(resolve, reject);
         },
         reject
       );
-
     })
     .then(this._activationSuccessfulMessage)
     .then(this._printSuccessMessage.bind(this))
@@ -70,7 +68,7 @@ module.exports = CoreObject.extend({
   },
 
   _list: function() {
-    return this.client.lrange(this.manifest, 0, this.manifestSize - 1)
+    return this.client.lrange(this.manifest, 0, this.manifestSize - 1);
   },
 
   _current: function() {
@@ -95,26 +93,35 @@ module.exports = CoreObject.extend({
     });  
   },
 
-  _activateVersion: function(activeKey, revisionKey) {
+  _activateVersion: function(revisionKey) {
     var client = this.client;
+    var currentKey = this._currentKey();
     var _this = this;
 
     return new RSVP.Promise(function(resolve, reject) {
-      if (_this.copyOnActivate) {
-        var key = _this._copyToKey();
+      _this._copyVersion(revisionKey).then(
+        function(test) {
+          client.set(currentKey, revisionKey).then(resolve, reject);
+        },
+        reject
+      );
+    });
+  },
 
-        client.get(revisionKey).then(
-          function(value) {
-            client.set(key, value).then(
-              client.set(activeKey, revisionKey).then(resolve, reject), 
-              reject
-            );
-          }, 
-          reject
-        );    
-      } else {
-        client.set(activeKey, revisionKey).then(resolve, reject);
+  _copyVersion: function(revisionKey) {
+    var client = this.client;
+    var copyTo = this.copyToKey;
+
+    return new RSVP.Promise(function(resolve, reject) {
+      if (!copyTo) {
+        resolve()
       }
+      client.get(revisionKey).then(
+        function(value) {
+          client.set(copyTo, value).then(resolve, reject);
+        },
+        reject
+      ); 
     });
   },
 
@@ -155,14 +162,6 @@ module.exports = CoreObject.extend({
   },
 
   _currentKey: function() {
-    if (this.copyOnActivate) {
-      return this.manifest+'-version'
-    }
-
-    return this.manifest+':current';
-  },
-
-  _copyToKey: function() {
     return this.manifest+':current';
   },
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -14,7 +14,13 @@ var white = chalk.white;
 module.exports = CoreObject.extend({
   init: function() {
     this.manifestSize = this.manifestSize || DEFAULT_MANIFEST_SIZE;
-    this.client       = redis.createClient(this.config);
+    
+    if (this.config.copyOnActivate) {
+      this.copyOnActivate = this.config.copyOnActivate;
+      delete this.config.copyOnActivate;
+    }
+
+    this.client = redis.createClient(this.config);
   },
 
   upload: function(value) {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -16,7 +16,7 @@ module.exports = CoreObject.extend({
     this.manifestSize = this.manifestSize || DEFAULT_MANIFEST_SIZE;
     
     if (this.config.copyOnActivate) {
-      this.copyOnActivate = this.config.copyOnActivate;
+      this.copyOnActivate = true;
       delete this.config.copyOnActivate;
     }
 
@@ -46,23 +46,21 @@ module.exports = CoreObject.extend({
   },
 
   activate: function(revisionKey) {
-
     if (!revisionKey) {
       return this._printErrorMessage(this._noRevisionPassedMessage());
     };
 
-    var uploadKey = this._currentKey();
+    var currentKey = this._currentKey();
     var that      = this;
 
     return new RSVP.Promise(function(resolve, reject) {
-      that._list()
-        .then(function(uploads) {
-          return uploads.indexOf(revisionKey) > -1 ? resolve() : reject();
-        })
-        .then(function() {
-          return that._activateVersion(uploadKey, revisionKey);
-        })
-        .then(resolve);
+      that._checkVersion(revisionKey).then(
+        function() {
+          that._activateVersion(currentKey, revisionKey).then(resolve, reject);
+        },
+        reject
+      );
+
     })
     .then(this._activationSuccessfulMessage)
     .then(this._printSuccessMessage.bind(this))
@@ -87,20 +85,37 @@ module.exports = CoreObject.extend({
     });
   },
 
+  _checkVersion: function(version) {
+    var _this = this;
+
+    return new RSVP.Promise(function(resolve, reject) {
+      _this._list().then(function(uploads) {
+        uploads.indexOf(version) > -1 ? resolve() : reject();
+      }, reject);
+    });  
+  },
+
   _activateVersion: function(activeKey, revisionKey) {
     var client = this.client;
+    var _this = this;
 
-    if (this.copyOnActivate) {
-      var key = this._copyToKey();
+    return new RSVP.Promise(function(resolve, reject) {
+      if (_this.copyOnActivate) {
+        var key = _this._copyToKey();
 
-      return client.get(revisionKey).then(function(value) {
-        return client.set(key, value).then(function() {
-          return client.set(activeKey, revisionKey);
-        });
-      });
-    }
-
-    return client.set(activeKey, revisionKey);
+        client.get(revisionKey).then(
+          function(value) {
+            client.set(key, value).then(
+              client.set(activeKey, revisionKey).then(resolve, reject), 
+              reject
+            );
+          }, 
+          reject
+        );    
+      } else {
+        client.set(activeKey, revisionKey).then(resolve, reject);
+      }
+    });
   },
 
   _upload: function(value, key) {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -40,6 +40,7 @@ module.exports = CoreObject.extend({
   },
 
   activate: function(revisionKey) {
+
     if (!revisionKey) {
       return this._printErrorMessage(this._noRevisionPassedMessage());
     };
@@ -53,7 +54,7 @@ module.exports = CoreObject.extend({
           return uploads.indexOf(revisionKey) > -1 ? resolve() : reject();
         })
         .then(function() {
-          return that.client.set(uploadKey, revisionKey);
+          return that._activateVersion(uploadKey, revisionKey);
         })
         .then(resolve);
     })
@@ -78,6 +79,22 @@ module.exports = CoreObject.extend({
     return new TaggingAdapter({
       manifest: this.manifest
     });
+  },
+
+  _activateVersion: function(activeKey, revisionKey) {
+    var client = this.client;
+
+    if (this.copyOnActivate) {
+      var key = this._copyToKey();
+
+      return client.get(revisionKey).then(function(value) {
+        return client.set(key, value).then(function() {
+          return client.set(activeKey, revisionKey);
+        });
+      });
+    }
+
+    return client.set(activeKey, revisionKey);
   },
 
   _upload: function(value, key) {
@@ -117,6 +134,14 @@ module.exports = CoreObject.extend({
   },
 
   _currentKey: function() {
+    if (this.copyOnActivate) {
+      return this.manifest+'-version'
+    }
+
+    return this.manifest+':current';
+  },
+
+  _copyToKey: function() {
     return this.manifest+':current';
   },
 

--- a/node_tests/unit/lib/redis-test.js
+++ b/node_tests/unit/lib/redis-test.js
@@ -331,12 +331,9 @@ describe('RedisAdapter with copyOnActivate option', function() {
 
         it('copies version value to current version value', function() {
           return activation
-            .then(function() {
-              return redisClient.get(revisionToActivate)
-            })
-            .then(function(newValue) {
+           .then(function(newValue) {
               return redisClient.get(MANIFEST+':current').then(function(activeValue) {
-                return expect(newValue).to.eq(activeValue);
+                return expect(activeValue).to.eq('Hello');
               })
             });
         });

--- a/node_tests/unit/lib/redis-test.js
+++ b/node_tests/unit/lib/redis-test.js
@@ -283,7 +283,7 @@ describe('RedisAdapter with copyOnActivate option', function() {
       manifest: MANIFEST,
       manifestSize: MANIFEST_SIZE,
       taggingAdapter: mockShaTaggingAdapter,
-      copyOnActivate: true,
+      copyToKey: 'current-copy',
       ui: new MockUI()
     });
 
@@ -319,20 +319,10 @@ describe('RedisAdapter with copyOnActivate option', function() {
             });
         });
 
-        it('sets <manifest>-version to active ', function() {
-          return activation
-            .then(function() {
-              return redisClient.get(MANIFEST+'-version');
-            })
-            .then(function(result) {
-              return expect(result).to.eq(revisionToActivate);
-            });
-        });
-
         it('copies version value to current version value', function() {
           return activation
            .then(function(newValue) {
-              return redisClient.get(MANIFEST+':current').then(function(activeValue) {
+              return redisClient.get('current-copy').then(function(activeValue) {
                 return expect(activeValue).to.eq('Hello');
               })
             });


### PR DESCRIPTION
Implement feature to make it easy to use nginx to serve the index page. Nginx config example at ember-cli/ember-cli-deploy#91

This pr adds a config option `copyToKey`. When defined the activate function copies the value of the specified version to the `copyToKey` value record.  This makes it easy to serve the index page from nginx without having to do a primary lookup.

Example.

```
//my-app/config/deploy.js
module.exports = {
  production: {
    store: {
      type: 'redis',
      host: 'localhost',
      port: 6379,
      copyToKey: 'current-copy'
    },
}
```
# nginx config

```
#this sets a variable $app_version from a url parameter version or defaults to 'current-copy'
map $arg_version $app_version {
    default "current-copy";
    ~^\w+ $arg_version;
}
upstream redisbackend{
    server 127.0.0.1:6379;
}
server {
    location / {
        set $redis_key my-app:$app_version;
        redis_pass redisbackend;
        default_type text/html;
    }
}
```
