### PR TITLE
Allow camelCase auth_pass in adapter config

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -13,6 +13,9 @@ var white = chalk.white;
 
 module.exports = CoreObject.extend({
   init: function() {
+    if ('authPass' in Object(this.config)) {
+      this.config.auth_pass = this.config.authPass;
+    }
     this.manifestSize = this.manifestSize || DEFAULT_MANIFEST_SIZE;
     this.client       = redis.createClient(this.config);
   },


### PR DESCRIPTION
node_redis uses underscores_for_everything but we ember peeps prefer our camelCase. This mates the two, allowing ember devs to define `authPass` in their deploy config, keeping things consistent and pretty, but not breaking things if they do in fact guess `auth_pass` first.
