### PR TITLE
Updated docs to clarify tunnel-ssh options

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This is the redis-adapter implementation to use [Redis](http://redis.io) with
 
 ## Securely deploying your app
 
-If your redis instance is isolated in a local intranet for security purposes, there is an option to open a SSH tunnel to the redis instance. To configure your ssh tunnel, provide the configuration in your environment:
+If your redis instance is isolated in a local intranet for security purposes, there is an option to open a SSH tunnel to the redis instance. To configure your ssh tunnel, provide the configuration in your environment.
+
+### Deploying to a local machine
 
 ```javascript
 module.exports = {
@@ -14,14 +16,31 @@ module.exports = {
     store: {
       type: 'redis',
       host: '10.12.0.0',
-      port: 6379,
-      ssh: {
-        username: 'deploy',
-        privateKey: '~/.ssh/id_rsa'
-      }
+      port: 6379
     }
   }
 };
 ```
 
+### Deploying to external machine (reachable through ssh)
+
+The ssh object will pass directly to [tunnel-ssh](https://github.com/Finanzchef24-GmbH/tunnel-ssh) so you can add any options to configure the tunnel destination host (dstHost) and port (dstPort), useful for instances where the default localhost isn't where your redis lives.
+
+```javascript
+module.exports = {
+  development: {
+    buildEnv: 'production',
+    store: {
+      type: 'redis',
+      ssh: {
+        host: 'ember-deploy-redis.com',
+        username: 'deploy',
+        privateKey: '~/.ssh/id_rsa',
+        dstPort: 6379, // redis port
+        dstHost: 'localhost' // redis host
+      }
+    }
+  }
+};
+```
 Note that the `privateKey` is a path to the SSH private key to access the machine that your redis instance is on, not a full blown key.

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -35,8 +35,8 @@ function RedisClient(config) {
       return error('Port ' + localPort + ' is not available to open a SSH connection on.\n' +
                    'Please choose a port between ' + MIN_PORT_NUMBER + ' and ' + MAX_PORT_NUMBER + '.');
     }
-    sshConfig.host = config.host;
-    sshConfig.dstPort = config.port;
+    sshConfig.host = sshConfig.host || config.host;
+    sshConfig.dstPort = sshConfig.dstPort || config.port;
     sshConfig.localPort = localPort;
     if (sshConfig.privateKey) {
       sshConfig.privateKey = fs.readFileSync(untildify(sshConfig.privateKey));


### PR DESCRIPTION
Updated the docs to clarify tunnel-ssh involvement in ssh mode

I also added two different config examples and using ssh.dstPort and ssh.host if they're set over the main config options, it might have been a bit too much to change, but it makes more sense grouped this way (at least to me), you can still specify host and port the old way.

Let me know if something needs to be changed!
